### PR TITLE
아이디, 닉네임 중복확인 API 추가

### DIFF
--- a/src/main/java/com/chingubackend/controller/UserController.java
+++ b/src/main/java/com/chingubackend/controller/UserController.java
@@ -36,7 +36,9 @@ public class UserController {
     }
 
     @GetMapping("/check-nickname")
-    public ResponseEntity<Boolean> checkNickname(@RequestParam String nickname) {
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임이 사용 가능한지 확인합니다.")
+    public ResponseEntity<Boolean> checkNickname(
+            @Parameter(description = "확인할 닉네임", example = "nickname123") @RequestParam String nickname) {
         boolean isAvailable = userService.isNicknameAvailable(nickname);
         return ResponseEntity.ok(isAvailable);
     }

--- a/src/main/java/com/chingubackend/controller/UserController.java
+++ b/src/main/java/com/chingubackend/controller/UserController.java
@@ -6,9 +6,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,5 +24,11 @@ public class UserController {
     public ResponseEntity<String> signup(@Valid @RequestBody SignupRequest request) {
         userService.registerUser(request);
         return ResponseEntity.ok("회원가입 성공");
+    }
+
+    @GetMapping("/check-userId")
+    public ResponseEntity<Boolean> checkUserId(@RequestParam String userId) {
+        boolean isAvailable = userService.isUserIdAvailable(userId);
+        return ResponseEntity.ok(isAvailable);
     }
 }

--- a/src/main/java/com/chingubackend/controller/UserController.java
+++ b/src/main/java/com/chingubackend/controller/UserController.java
@@ -31,4 +31,10 @@ public class UserController {
         boolean isAvailable = userService.isUserIdAvailable(userId);
         return ResponseEntity.ok(isAvailable);
     }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Boolean> checkNickname(@RequestParam String nickname) {
+        boolean isAvailable = userService.isNicknameAvailable(nickname);
+        return ResponseEntity.ok(isAvailable);
+    }
 }

--- a/src/main/java/com/chingubackend/controller/UserController.java
+++ b/src/main/java/com/chingubackend/controller/UserController.java
@@ -3,6 +3,7 @@ package com.chingubackend.controller;
 import com.chingubackend.dto.request.SignupRequest;
 import com.chingubackend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,9 @@ public class UserController {
     }
 
     @GetMapping("/check-userId")
-    public ResponseEntity<Boolean> checkUserId(@RequestParam String userId) {
+    @Operation(summary = "아이디 중복 확인", description = "아이디가 사용 가능한지 확인합니다.")
+    public ResponseEntity<Boolean> checkUserId(
+            @Parameter(description = "확인할 아이디", example = "user123") @RequestParam String userId) {
         boolean isAvailable = userService.isUserIdAvailable(userId);
         return ResponseEntity.ok(isAvailable);
     }

--- a/src/main/java/com/chingubackend/service/UserService.java
+++ b/src/main/java/com/chingubackend/service/UserService.java
@@ -17,18 +17,6 @@ public class UserService {
 
     @Transactional
     public void registerUser(SignupRequest request) {
-        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
-            throw new IllegalStateException("이미 가입된 이메일입니다.");
-        }
-
-        if (userRepository.findByUserId(request.getUserId()).isPresent()) {
-            throw new IllegalStateException("이미 사용 중인 아이디입니다.");
-        }
-
-        if (userRepository.findByNickname(request.getNickname()).isPresent()) {
-            throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
-        }
-
         User user = User.builder()
                 .userId(request.getUserId())
                 .name(request.getName())
@@ -41,6 +29,11 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+    }
+
+    @Transactional
+    public boolean isUserIdAvailable(String userId) {
+        return userRepository.findByUserId(userId).isEmpty();
     }
 
 }

--- a/src/main/java/com/chingubackend/service/UserService.java
+++ b/src/main/java/com/chingubackend/service/UserService.java
@@ -36,4 +36,9 @@ public class UserService {
         return userRepository.findByUserId(userId).isEmpty();
     }
 
+    @Transactional
+    public boolean isNicknameAvailable(String nickname) {
+        return userRepository.findByNickname(nickname).isEmpty();
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

resolves: #10 

## 📝작업 내용

- 아이디 중복 확인 API 를 추가하였습니다.
- 닉네임 중복 확인 API를 추가하였습니다.

## 💬 참고

- 이메일 중복 확인은 이메일 인증 시 동일한 이메일이 있다면 인증 메일이 가지 않게 하려고 합니다.
- User Entity, Service 코드 리팩토링은 로그인, 로그아웃 기능 구현 후 하려고 합니다.
