### PR TITLE
회원 탈퇴 시 그룹 생성자 이전 및 개인 일정 삭제 처리

### DIFF
--- a/src/main/java/com/chingubackend/dto/response/GroupResponse.java
+++ b/src/main/java/com/chingubackend/dto/response/GroupResponse.java
@@ -1,5 +1,6 @@
 package com.chingubackend.dto.response;
 
+import com.chingubackend.entity.Group;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,5 +12,21 @@ public class GroupResponse {
     private Long groupId;
     private String groupName;
     private String description;
+    private String creatorNickname;
     private LocalDateTime createdAt;
+
+    public static GroupResponse fromEntity(Group group) {
+        String creatorUserId = group.getCreator().getUserId();
+        String creatorNickname = creatorUserId.equals("deleted-user")
+                ? "탈퇴한 사용자"
+                : group.getCreator().getNickname();
+
+        return GroupResponse.builder()
+                .groupId(group.getId())
+                .groupName(group.getGroupName())
+                .description(group.getDescription())
+                .creatorNickname(creatorNickname)
+                .createdAt(group.getCreatedAt())
+                .build();
+    }
 }

--- a/src/main/java/com/chingubackend/entity/Group.java
+++ b/src/main/java/com/chingubackend/entity/Group.java
@@ -27,7 +27,7 @@ public class Group {
     private LocalDateTime createdAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "creator_id", nullable = false)
+    @JoinColumn(name = "creator_id", nullable = true)
     private User creator;
 
     @PrePersist

--- a/src/main/java/com/chingubackend/repository/GroupRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupRepository.java
@@ -1,10 +1,15 @@
 package com.chingubackend.repository;
 
 import com.chingubackend.entity.Group;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findByCreatorId(Long creatorId);
-
+    @Modifying
+    @Query("UPDATE Group g SET g.creator.id = :newCreatorId WHERE g.creator.id = :originalCreatorId")
+    void updateCreatorId(@Param("originalCreatorId") Long originalCreatorId, @Param("newCreatorId") Long newCreatorId);
 }

--- a/src/main/java/com/chingubackend/repository/ScheduleRepository.java
+++ b/src/main/java/com/chingubackend/repository/ScheduleRepository.java
@@ -11,4 +11,5 @@ import java.util.List;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     List<Schedule> findByUser(User user);
     List<Schedule> findByUser_Id(Long userId);
+    void deleteByUser(User user);
 }

--- a/src/main/java/com/chingubackend/service/UserService.java
+++ b/src/main/java/com/chingubackend/service/UserService.java
@@ -15,6 +15,7 @@ import com.chingubackend.repository.GroupMemberRepository;
 import com.chingubackend.repository.GroupRepository;
 import com.chingubackend.repository.GroupScheduleRepository;
 import com.chingubackend.repository.MessageRepository;
+import com.chingubackend.repository.ScheduleRepository;
 import com.chingubackend.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
@@ -37,6 +38,7 @@ public class UserService {
     private final GroupScheduleRepository groupScheduleRepository;
     private final GroupRepository groupRepository;
     private final MessageRepository messageRepository;
+    private final ScheduleRepository scheduleRepository;
 
     @Transactional
     public void registerUser(UserRequest request) {
@@ -105,6 +107,7 @@ public class UserService {
 
         messageRepository.deleteBySenderIdOrReceiverId(user.getId(), user.getId());
         groupInviteRepository.deleteBySenderIdOrReceiverId(user.getId(), user.getId());
+        scheduleRepository.deleteByUser(user);
         groupMemberRepository.deleteByUserId(user.getId());
         groupScheduleRepository.deleteByUser(user);
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: #71 

## 📝작업 내용

- 회원 탈퇴 시, 생성한 그룹의 `creator_id`를 시스템 사용자(`deleted-user`)로 이전
- `GroupRepository.updateCreatorId(...)` JPQL 메서드 구현
- `ScheduleRepository.deleteByUser(...)` 메서드 추가
- UserService.deleteUser() 내에 개인 일정 삭제 처리 로직 추가


## 💬 참고 사항

- 탈퇴한 사용자와 관련된 그룹/일정 데이터 정리로 FK 제약 오류 해결
- 시스템 계정 `deleted-user`는 DB에 미리 존재해야 함
