### PR TITLE
그룹 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/chingubackend/controller/AlbumImageUploadController.java
+++ b/src/main/java/com/chingubackend/controller/AlbumImageUploadController.java
@@ -1,0 +1,38 @@
+package com.chingubackend.controller;
+
+import com.chingubackend.service.S3Service;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/albums")
+@RequiredArgsConstructor
+public class AlbumImageUploadController {
+
+    private final S3Service s3Service;
+
+    @GetMapping("/upload-url")
+    public ResponseEntity<Map<String, String>> getAlbumUploadUrl(
+            @RequestParam(defaultValue = "jpg") String extension,
+            HttpServletRequest request) {
+
+        Long userId = (Long) request.getAttribute("userId");
+
+        String ext = extension.startsWith(".") ? extension : "." + extension;
+        String key = "albums/" + userId + "/" + UUID.randomUUID() + ext;
+
+        URL uploadUrl = s3Service.generatePreSignedUrl(key);
+        String fileUrl = s3Service.getFileUrl(key);
+
+        return ResponseEntity.ok(Map.of(
+                "uploadUrl", uploadUrl.toString(),
+                "fileUrl", fileUrl
+        ));
+    }
+}

--- a/src/main/java/com/chingubackend/controller/GroupController.java
+++ b/src/main/java/com/chingubackend/controller/GroupController.java
@@ -4,6 +4,7 @@ import com.chingubackend.dto.request.GroupInviteRequest;
 import com.chingubackend.dto.request.GroupInviteStatusRequest;
 import com.chingubackend.dto.request.GroupRequest;
 import com.chingubackend.dto.response.GroupDeleteResponse;
+import com.chingubackend.dto.response.GroupDetailResponse;
 import com.chingubackend.dto.response.GroupInviteResponse;
 import com.chingubackend.dto.response.GroupInviteResponse.GroupInviteResponseWithoutFriend;
 import com.chingubackend.dto.response.GroupResponse;
@@ -110,4 +111,16 @@ public class GroupController {
         List<GroupInviteResponse> invites = groupService.getGroupInvites(groupId);
         return ResponseEntity.ok(invites);
     }
+
+    @Operation(summary = "그룹 상세 조회")
+    @GetMapping("/{groupId}")
+    public ResponseEntity<GroupDetailResponse> getGroupDetail(
+            @PathVariable Long groupId,
+            HttpServletRequest request
+    ) {
+        Long userId = (Long) request.getAttribute("userId");
+        GroupDetailResponse response = groupService.getGroupDetail(groupId, userId);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/chingubackend/controller/GroupController.java
+++ b/src/main/java/com/chingubackend/controller/GroupController.java
@@ -99,6 +99,10 @@ public class GroupController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(
+            summary = "내가 속한 그룹 목록 조회",
+            description = "로그인한 사용자가 속해 있는 그룹 목록을 조회합니다. 생성한 그룹과 가입한 그룹 모두 포함됩니다."
+    )
     @GetMapping("/mygroups")
     public ResponseEntity<List<GroupResponse>> getMyGroups(HttpServletRequest request) {
         Long userId = (Long) request.getAttribute("userId");
@@ -106,6 +110,10 @@ public class GroupController {
         return ResponseEntity.ok(groups);
     }
 
+    @Operation(
+            summary = "그룹 초대 목록 조회",
+            description = "해당 그룹에 초대한 사용자 목록을 조회합니다."
+    )
     @GetMapping("/{groupId}/invites")
     public ResponseEntity<List<GroupInviteResponse>> getGroupInvites(@PathVariable Long groupId) {
         List<GroupInviteResponse> invites = groupService.getGroupInvites(groupId);

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -98,4 +98,16 @@ public class GroupMemoryController {
         List<GroupMemoryListResponse> response = groupMemoryService.getGroupMemories(groupId, userId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "그룹 추억 앨범 글 상세 조회")
+    @GetMapping("/{memoryId}")
+    public ResponseEntity<GroupMemoryResponse> getMemoryDetail(
+            @PathVariable Long groupId,
+            @PathVariable Long memoryId,
+            HttpServletRequest httpRequest) {
+
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        GroupMemoryResponse response = groupMemoryService.getMemoryDetail(groupId, memoryId, userId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -1,0 +1,34 @@
+package com.chingubackend.controller;
+
+import com.chingubackend.dto.request.GroupMemoryRequest;
+import com.chingubackend.dto.response.GroupMemoryResponse;
+import com.chingubackend.service.GroupMemoryService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/groups/{groupId}/albums")
+@RequiredArgsConstructor
+public class GroupMemoryController {
+
+    private final GroupMemoryService groupMemoryService;
+
+    @PostMapping
+    public ResponseEntity<GroupMemoryResponse> createMemory(
+            @PathVariable Long groupId,
+            @RequestBody @Valid GroupMemoryRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        GroupMemoryResponse response = groupMemoryService.createGroupMemory(groupId, userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -2,6 +2,7 @@ package com.chingubackend.controller;
 
 import com.chingubackend.dto.request.GroupMemoryRequest;
 import com.chingubackend.dto.request.GroupMemoryUpdateRequest;
+import com.chingubackend.dto.response.GroupMemoryListResponse;
 import com.chingubackend.dto.response.GroupMemoryResponse;
 import com.chingubackend.service.GroupMemoryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,11 +10,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -85,4 +88,14 @@ public class GroupMemoryController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "그룹 추억 앨범 글 리스트 조회")
+    @GetMapping
+    public ResponseEntity<List<GroupMemoryListResponse>> getMemories(
+            @PathVariable Long groupId,
+            HttpServletRequest httpRequest) {
+
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        List<GroupMemoryListResponse> response = groupMemoryService.getGroupMemories(groupId, userId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -3,6 +3,9 @@ package com.chingubackend.controller;
 import com.chingubackend.dto.request.GroupMemoryRequest;
 import com.chingubackend.dto.response.GroupMemoryResponse;
 import com.chingubackend.service.GroupMemoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +25,13 @@ public class GroupMemoryController {
     private final GroupMemoryService groupMemoryService;
 
     @PostMapping
+    @Operation(summary = "추억 앨범 글 작성", description = "그룹 ID를 기반으로 추억 앨범 글을 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "작성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
     public ResponseEntity<GroupMemoryResponse> createMemory(
             @PathVariable Long groupId,
             @RequestBody @Valid GroupMemoryRequest request,

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -1,6 +1,7 @@
 package com.chingubackend.controller;
 
 import com.chingubackend.dto.request.GroupMemoryRequest;
+import com.chingubackend.dto.request.GroupMemoryUpdateRequest;
 import com.chingubackend.dto.response.GroupMemoryResponse;
 import com.chingubackend.service.GroupMemoryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,4 +43,25 @@ public class GroupMemoryController {
         GroupMemoryResponse response = groupMemoryService.createGroupMemory(groupId, userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @PatchMapping("/{memoryId}")
+    @Operation(summary = "추억 앨범 글 수정", description = "작성자만 수정할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "글 또는 그룹 없음")
+    })
+    public ResponseEntity<GroupMemoryResponse> updateMemory(
+            @PathVariable Long groupId,
+            @PathVariable Long memoryId,
+            @RequestBody @Valid GroupMemoryUpdateRequest request,
+            HttpServletRequest httpRequest) {
+
+        Long userId = (Long) httpRequest.getAttribute("userId");
+        GroupMemoryResponse response = groupMemoryService.updateGroupMemory(groupId, memoryId, userId, request);
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/chingubackend/controller/GroupMemoryController.java
+++ b/src/main/java/com/chingubackend/controller/GroupMemoryController.java
@@ -9,9 +9,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -61,6 +63,25 @@ public class GroupMemoryController {
 
         Long userId = (Long) httpRequest.getAttribute("userId");
         GroupMemoryResponse response = groupMemoryService.updateGroupMemory(groupId, memoryId, userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{memoryId}")
+    @Operation(summary = "추억 앨범 글 삭제", description = "작성자 본인만 삭제 가능합니다.")
+    public ResponseEntity<Map<String, Object>> deleteMemory(
+            @PathVariable Long groupId,
+            @PathVariable Long memoryId,
+            HttpServletRequest request
+    ) {
+        Long userId = (Long) request.getAttribute("userId");
+        groupMemoryService.deleteGroupMemory(groupId, memoryId, userId);
+
+        Map<String, Object> response = Map.of(
+                "message", "추억 앨범 글이 성공적으로 삭제되었습니다.",
+                "memoryId", memoryId,
+                "groupId", groupId
+        );
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/chingubackend/dto/request/GroupMemoryRequest.java
+++ b/src/main/java/com/chingubackend/dto/request/GroupMemoryRequest.java
@@ -1,0 +1,27 @@
+package com.chingubackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupMemoryRequest {
+    @NotBlank
+    private String title;
+
+    private String content;
+
+    @NotBlank
+    private String imageUrl1;
+
+    private String imageUrl2;
+    private String imageUrl3;
+
+    private String location;
+
+    @NotNull
+    private LocalDate memoryDate;
+}

--- a/src/main/java/com/chingubackend/dto/request/GroupMemoryUpdateRequest.java
+++ b/src/main/java/com/chingubackend/dto/request/GroupMemoryUpdateRequest.java
@@ -1,0 +1,25 @@
+package com.chingubackend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GroupMemoryUpdateRequest {
+    @NotBlank
+    private String title;
+
+    private String content;
+
+    private String imageUrl1;
+    private String imageUrl2;
+    private String imageUrl3;
+
+    private String location;
+
+    @NotNull
+    private LocalDate memoryDate;
+}

--- a/src/main/java/com/chingubackend/dto/response/GroupDetailResponse.java
+++ b/src/main/java/com/chingubackend/dto/response/GroupDetailResponse.java
@@ -1,0 +1,25 @@
+package com.chingubackend.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GroupDetailResponse {
+    private Long groupId;
+    private String groupName;
+    private String description;
+    private LocalDateTime createdAt;
+    private List<GroupAlbumSummary> groupMemories;
+
+    @Getter
+    @Builder
+    public static class GroupAlbumSummary {
+        private Long albumId;
+        private String albumTitle;
+        private String albumImage;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/chingubackend/dto/response/GroupMemoryListResponse.java
+++ b/src/main/java/com/chingubackend/dto/response/GroupMemoryListResponse.java
@@ -1,0 +1,16 @@
+package com.chingubackend.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GroupMemoryListResponse {
+    private Long memoryId;
+    private String imageUrl;
+    private String description;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/chingubackend/dto/response/GroupMemoryResponse.java
+++ b/src/main/java/com/chingubackend/dto/response/GroupMemoryResponse.java
@@ -1,0 +1,24 @@
+package com.chingubackend.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GroupMemoryResponse {
+    private Long memoryId;
+    private Long groupId;
+    private String nickname;
+    private String title;
+    private String content;
+    private String imageUrl1;
+    private String imageUrl2;
+    private String imageUrl3;
+    private String location;
+    private LocalDate memoryDate;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/chingubackend/dto/response/GroupResponse.java
+++ b/src/main/java/com/chingubackend/dto/response/GroupResponse.java
@@ -12,21 +12,5 @@ public class GroupResponse {
     private Long groupId;
     private String groupName;
     private String description;
-    private String creatorNickname;
     private LocalDateTime createdAt;
-
-    public static GroupResponse fromEntity(Group group) {
-        String creatorUserId = group.getCreator().getUserId();
-        String creatorNickname = creatorUserId.equals("deleted-user")
-                ? "탈퇴한 사용자"
-                : group.getCreator().getNickname();
-
-        return GroupResponse.builder()
-                .groupId(group.getId())
-                .groupName(group.getGroupName())
-                .description(group.getDescription())
-                .creatorNickname(creatorNickname)
-                .createdAt(group.getCreatedAt())
-                .build();
-    }
 }

--- a/src/main/java/com/chingubackend/entity/GroupMember.java
+++ b/src/main/java/com/chingubackend/entity/GroupMember.java
@@ -1,5 +1,6 @@
 package com.chingubackend.entity;
 
+import com.chingubackend.model.MemberStatus;
 import com.chingubackend.model.RequestStatus;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -28,7 +29,7 @@ public class GroupMember {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private RequestStatus status;
+    private MemberStatus status;
 
     @Column(name = "joined_at", nullable = false)
     private LocalDateTime joinedAt;
@@ -39,7 +40,7 @@ public class GroupMember {
     }
 
     @Builder
-    public GroupMember(Group group, User user, RequestStatus status) {
+    public GroupMember(Group group, User user, MemberStatus status) {
         this.group = group;
         this.user = user;
         this.status = status;

--- a/src/main/java/com/chingubackend/entity/GroupMemory.java
+++ b/src/main/java/com/chingubackend/entity/GroupMemory.java
@@ -1,0 +1,79 @@
+package com.chingubackend.entity;
+
+import com.chingubackend.entity.Group;
+import com.chingubackend.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "group_memories")
+public class GroupMemory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "image_url_1")
+    private String imageUrl1;
+
+    @Column(name = "image_url_2")
+    private String imageUrl2;
+
+    @Column(name = "image_url_3")
+    private String imageUrl3;
+
+    private String location;
+
+    @Column(name = "memory_date")
+    private LocalDate memoryDate;
+
+    @Column(name = "created_date", updatable = false)
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    @Column(name = "modify_date")
+    private LocalDateTime modifyDate = LocalDateTime.now();
+
+    @Builder
+    public GroupMemory(Group group, User user, String title, String content,
+                       String imageUrl1, String imageUrl2, String imageUrl3,
+                       String location, LocalDate memoryDate) {
+        this.group = group;
+        this.user = user;
+        this.title = title;
+        this.content = content;
+        this.imageUrl1 = imageUrl1;
+        this.imageUrl2 = imageUrl2;
+        this.imageUrl3 = imageUrl3;
+        this.location = location;
+        this.memoryDate = memoryDate;
+        this.createdDate = LocalDateTime.now();
+        this.modifyDate = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/chingubackend/entity/GroupMemory.java
+++ b/src/main/java/com/chingubackend/entity/GroupMemory.java
@@ -1,5 +1,6 @@
 package com.chingubackend.entity;
 
+import com.chingubackend.dto.request.GroupMemoryUpdateRequest;
 import com.chingubackend.entity.Group;
 import com.chingubackend.entity.User;
 import jakarta.persistence.Column;
@@ -76,4 +77,16 @@ public class GroupMemory {
         this.createdDate = LocalDateTime.now();
         this.modifyDate = LocalDateTime.now();
     }
+
+    public void update(GroupMemoryUpdateRequest dto) {
+        this.title = dto.getTitle();
+        this.content = dto.getContent();
+        this.imageUrl1 = dto.getImageUrl1();
+        this.imageUrl2 = dto.getImageUrl2();
+        this.imageUrl3 = dto.getImageUrl3();
+        this.location = dto.getLocation();
+        this.memoryDate = dto.getMemoryDate();
+        this.modifyDate = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/chingubackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chingubackend/exception/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.chingubackend.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.validation.FieldError;
 
 import java.time.LocalDateTime;
 
@@ -55,6 +59,17 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ImageUploadException.class)
     public ResponseEntity<ErrorResponse> handleImageUploadException(ImageUploadException ex) {
         return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Image Upload Failed", ex.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<String> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
+                .toList();
+
+        String errorMessage = String.join("; ", errors);
+
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Validation Failed", errorMessage);
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String error, String message) {

--- a/src/main/java/com/chingubackend/model/MemberStatus.java
+++ b/src/main/java/com/chingubackend/model/MemberStatus.java
@@ -1,0 +1,5 @@
+package com.chingubackend.model;
+
+public enum MemberStatus {
+    APPROVED, PENDING, REJECTED
+}

--- a/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
@@ -16,5 +16,4 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     void deleteByUserId(Long userId);
     boolean existsByGroupIdAndUserId(Long groupId, Long userId);
-
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
@@ -11,5 +11,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     List<GroupMember> findByGroupId(Long groupId);
     Optional<GroupMember> findByGroupIdAndUserId(Long groupId, Long userId);
     List<GroupMember> findByUserIdAndStatus(Long userId, RequestStatus status);
+
     void deleteByUserId(Long userId);
+    boolean existsByGroupIdAndUserId(Long groupId, Long userId);
+
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
@@ -1,6 +1,7 @@
 package com.chingubackend.repository;
 
 import com.chingubackend.entity.GroupMember;
+import com.chingubackend.model.MemberStatus;
 import com.chingubackend.model.RequestStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,7 +11,8 @@ import java.util.Optional;
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
     List<GroupMember> findByGroupId(Long groupId);
     Optional<GroupMember> findByGroupIdAndUserId(Long groupId, Long userId);
-    List<GroupMember> findByUserIdAndStatus(Long userId, RequestStatus status);
+    List<GroupMember> findByUserIdAndStatus(Long userId, MemberStatus status);
+
 
     void deleteByUserId(Long userId);
     boolean existsByGroupIdAndUserId(Long groupId, Long userId);

--- a/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
@@ -1,7 +1,14 @@
 package com.chingubackend.repository;
 
 import com.chingubackend.entity.GroupMemory;
+import com.chingubackend.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupMemoryRepository extends JpaRepository<GroupMemory, Long> {
+    @Modifying
+    @Query("UPDATE GroupMemory gm SET gm.user = :systemUser WHERE gm.user = :user")
+    void reassignMemoriesToSystem(@Param("user") User user, @Param("systemUser") User systemUser);
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
@@ -15,5 +15,6 @@ public interface GroupMemoryRepository extends JpaRepository<GroupMemory, Long> 
     void reassignMemoriesToSystem(@Param("user") User user, @Param("systemUser") User systemUser);
 
     List<GroupMemory> findByGroupId(Long groupId);
+    List<GroupMemory> findByGroupIdOrderByCreatedDateDesc(Long groupId);
 
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
@@ -1,0 +1,7 @@
+package com.chingubackend.repository;
+
+import com.chingubackend.entity.GroupMemory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemoryRepository extends JpaRepository<GroupMemory, Long> {
+}

--- a/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
@@ -1,8 +1,10 @@
 package com.chingubackend.repository;
 
+import com.chingubackend.entity.Group;
 import com.chingubackend.entity.GroupMemory;
 import com.chingubackend.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +13,7 @@ public interface GroupMemoryRepository extends JpaRepository<GroupMemory, Long> 
     @Modifying
     @Query("UPDATE GroupMemory gm SET gm.user = :systemUser WHERE gm.user = :user")
     void reassignMemoriesToSystem(@Param("user") User user, @Param("systemUser") User systemUser);
+
+    List<GroupMemory> findByGroupId(Long groupId);
+
 }

--- a/src/main/java/com/chingubackend/service/GroupMemoryService.java
+++ b/src/main/java/com/chingubackend/service/GroupMemoryService.java
@@ -1,6 +1,7 @@
 package com.chingubackend.service;
 
 import com.chingubackend.dto.request.GroupMemoryRequest;
+import com.chingubackend.dto.request.GroupMemoryUpdateRequest;
 import com.chingubackend.dto.response.GroupMemoryResponse;
 import com.chingubackend.entity.Group;
 import com.chingubackend.entity.GroupMemory;
@@ -11,6 +12,7 @@ import com.chingubackend.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -58,4 +60,31 @@ public class GroupMemoryService {
                 .createdAt(saved.getCreatedDate())
                 .build();
     }
+
+    @Transactional
+    public GroupMemoryResponse updateGroupMemory(Long groupId, Long memoryId, Long userId, GroupMemoryUpdateRequest request) {
+        GroupMemory memory = groupMemoryRepository.findById(memoryId)
+                .orElseThrow(() -> new EntityNotFoundException("앨범 글을 찾을 수 없습니다."));
+
+        if (!memory.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException("작성자만 수정할 수 있습니다.");
+        }
+
+        memory.update(request);
+
+        return GroupMemoryResponse.builder()
+                .memoryId(memory.getId())
+                .groupId(groupId)
+                .nickname(memory.getUser().getNickname())
+                .title(memory.getTitle())
+                .content(memory.getContent())
+                .imageUrl1(memory.getImageUrl1())
+                .imageUrl2(memory.getImageUrl2())
+                .imageUrl3(memory.getImageUrl3())
+                .location(memory.getLocation())
+                .memoryDate(memory.getMemoryDate())
+                .createdAt(memory.getCreatedDate())
+                .build();
+    }
+
 }

--- a/src/main/java/com/chingubackend/service/GroupMemoryService.java
+++ b/src/main/java/com/chingubackend/service/GroupMemoryService.java
@@ -32,6 +32,11 @@ public class GroupMemoryService {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new EntityNotFoundException("그룹이 존재하지 않습니다."));
 
+        boolean isMember = groupMemberRepository.existsByGroupIdAndUserId(groupId, userId);
+        if (!isMember) {
+            throw new AccessDeniedException("해당 그룹에 속한 사용자만 글을 작성할 수 있습니다.");
+        }
+
         User user = userRepository.findById(userId)
                 .orElseGet(() -> userRepository.findByUserId("system")
                         .orElseThrow(() -> new IllegalStateException("시스템 사용자 정보가 없습니다.")));

--- a/src/main/java/com/chingubackend/service/GroupMemoryService.java
+++ b/src/main/java/com/chingubackend/service/GroupMemoryService.java
@@ -136,4 +136,37 @@ public class GroupMemoryService {
                 .toList();
     }
 
+    @Transactional
+    public GroupMemoryResponse getMemoryDetail(Long groupId, Long memoryId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new EntityNotFoundException("그룹을 찾을 수 없습니다."));
+
+        // 그룹 멤버 확인
+        boolean isMember = groupMemberRepository.existsByGroupIdAndUserId(groupId, userId);
+        if (!isMember) {
+            throw new AccessDeniedException("해당 그룹에 속한 사용자만 조회할 수 있습니다.");
+        }
+
+        GroupMemory memory = groupMemoryRepository.findById(memoryId)
+                .orElseThrow(() -> new EntityNotFoundException("앨범 글을 찾을 수 없습니다."));
+
+        if (!memory.getGroup().getId().equals(groupId)) {
+            throw new IllegalArgumentException("앨범 글이 해당 그룹에 속해있지 않습니다.");
+        }
+
+        return GroupMemoryResponse.builder()
+                .memoryId(memory.getId())
+                .groupId(groupId)
+                .nickname(memory.getUser().getNickname())
+                .title(memory.getTitle())
+                .content(memory.getContent())
+                .imageUrl1(memory.getImageUrl1())
+                .imageUrl2(memory.getImageUrl2())
+                .imageUrl3(memory.getImageUrl3())
+                .location(memory.getLocation())
+                .memoryDate(memory.getMemoryDate())
+                .createdAt(memory.getCreatedDate())
+                .build();
+    }
+
 }

--- a/src/main/java/com/chingubackend/service/GroupMemoryService.java
+++ b/src/main/java/com/chingubackend/service/GroupMemoryService.java
@@ -1,0 +1,61 @@
+package com.chingubackend.service;
+
+import com.chingubackend.dto.request.GroupMemoryRequest;
+import com.chingubackend.dto.response.GroupMemoryResponse;
+import com.chingubackend.entity.Group;
+import com.chingubackend.entity.GroupMemory;
+import com.chingubackend.entity.User;
+import com.chingubackend.repository.GroupMemoryRepository;
+import com.chingubackend.repository.GroupRepository;
+import com.chingubackend.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GroupMemoryService {
+
+    private final GroupRepository groupRepository;
+    private final UserRepository userRepository;
+    private final GroupMemoryRepository groupMemoryRepository;
+
+    @Transactional
+    public GroupMemoryResponse createGroupMemory(Long groupId, Long userId, GroupMemoryRequest request) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new EntityNotFoundException("그룹이 존재하지 않습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseGet(() -> userRepository.findByUserId("system")
+                        .orElseThrow(() -> new IllegalStateException("시스템 사용자 정보가 없습니다.")));
+
+        GroupMemory memory = GroupMemory.builder()
+                .group(group)
+                .user(user)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .imageUrl1(request.getImageUrl1())
+                .imageUrl2(request.getImageUrl2())
+                .imageUrl3(request.getImageUrl3())
+                .location(request.getLocation())
+                .memoryDate(request.getMemoryDate())
+                .build();
+
+        GroupMemory saved = groupMemoryRepository.save(memory);
+
+        return GroupMemoryResponse.builder()
+                .memoryId(saved.getId())
+                .groupId(groupId)
+                .nickname(user.getNickname())
+                .title(saved.getTitle())
+                .content(saved.getContent())
+                .imageUrl1(saved.getImageUrl1())
+                .imageUrl2(saved.getImageUrl2())
+                .imageUrl3(saved.getImageUrl3())
+                .location(saved.getLocation())
+                .memoryDate(saved.getMemoryDate())
+                .createdAt(saved.getCreatedDate())
+                .build();
+    }
+}

--- a/src/main/java/com/chingubackend/service/GroupMemoryService.java
+++ b/src/main/java/com/chingubackend/service/GroupMemoryService.java
@@ -87,4 +87,23 @@ public class GroupMemoryService {
                 .build();
     }
 
+    @Transactional
+    public void deleteGroupMemory(Long groupId, Long memoryId, Long userId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new EntityNotFoundException("그룹이 존재하지 않습니다."));
+
+        GroupMemory memory = groupMemoryRepository.findById(memoryId)
+                .orElseThrow(() -> new EntityNotFoundException("앨범 글이 존재하지 않습니다."));
+
+        if (!memory.getGroup().getId().equals(group.getId())) {
+            throw new IllegalArgumentException("그룹 정보가 일치하지 않습니다.");
+        }
+
+        if (!memory.getUser().getId().equals(userId)) {
+            throw new AccessDeniedException("삭제 권한이 없습니다.");
+        }
+
+        groupMemoryRepository.delete(memory);
+    }
+
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: #78 

## 📝작업 내용

- 그룹 상세 정보를 조회하는 API 구현
- 그룹 기본 정보 반환
- 해당 그룹에 작성된 추억 앨범 목록(albumId, albumTitle, albumImage, createdAt) 함께 반환
- 인증된 사용자이면서 해당 그룹의 멤버일 경우에만 접근 가능하도록 권한 처리


## 💬 참고 사항

- 추억 앨범 기능 기반으로 동작하므로 해당 기능이 선행되어야 함
- 정렬 기준: 앨범 createdDate 내림차순
