### PR TITLE
관리자 그룹 API 추가 및 권한 검사 로직 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,12 +42,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
-    // JWT 관련 의존성 추가
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // Websocket 의존성 추가
+    // Websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.655'

--- a/src/main/java/com/chingubackend/config/SecurityConfig.java
+++ b/src/main/java/com/chingubackend/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -22,6 +23,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
@@ -1,0 +1,42 @@
+package com.chingubackend.controller.admin;
+
+import com.chingubackend.dto.response.AdminGroupResponse;
+import com.chingubackend.entity.Group;
+import com.chingubackend.repository.GroupRepository;
+import com.chingubackend.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin", description = "관리자 전용 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminGroupController {
+
+    private final GroupRepository groupRepository;
+
+    @GetMapping("/groups")
+    @Operation(summary = "전체 그룹 및 멤버 목록 조회", description = "관리자가 전체 그룹 정보 및 구성원 목록을 확인할 수 있습니다.")
+    public ResponseEntity<List<AdminGroupResponse>> getAllGroups(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        List<Group> groups = groupRepository.findAllWithMembersAndUsers();
+
+        List<AdminGroupResponse> response = groups.stream()
+                .map(AdminGroupResponse::new)
+                .toList();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
@@ -10,9 +10,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -28,12 +27,10 @@ public class AdminGroupController {
     private final GroupRepository groupRepository;
     private final AdminGroupService adminGroupService;
 
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/groups")
     @Operation(summary = "전체 그룹 및 멤버 목록 조회", description = "관리자가 전체 그룹 정보 및 구성원 목록을 확인할 수 있습니다.")
-    public ResponseEntity<List<AdminGroupResponse>> getAllGroups(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
+    public ResponseEntity<List<AdminGroupResponse>> getAllGroups() {
 
         List<Group> groups = groupRepository.findAllWithMembersAndUsers();
 
@@ -44,15 +41,13 @@ public class AdminGroupController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/groups/{groupId}")
     @Operation(summary = "그룹 삭제", description = "관리자가 그룹을 삭제할 수 있습니다.")
     public ResponseEntity<?> deleteGroup(
             @PathVariable Long groupId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
 
         adminGroupService.deleteGroupByAdmin(groupId);
 

--- a/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminGroupController.java
@@ -4,6 +4,7 @@ import com.chingubackend.dto.response.AdminGroupResponse;
 import com.chingubackend.entity.Group;
 import com.chingubackend.repository.GroupRepository;
 import com.chingubackend.security.CustomUserDetails;
+import com.chingubackend.service.admin.AdminGroupService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -12,7 +13,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminGroupController {
 
     private final GroupRepository groupRepository;
+    private final AdminGroupService adminGroupService;
 
     @GetMapping("/groups")
     @Operation(summary = "전체 그룹 및 멤버 목록 조회", description = "관리자가 전체 그룹 정보 및 구성원 목록을 확인할 수 있습니다.")
@@ -39,4 +43,25 @@ public class AdminGroupController {
 
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/groups/{groupId}")
+    @Operation(summary = "그룹 삭제", description = "관리자가 그룹을 삭제할 수 있습니다.")
+    public ResponseEntity<?> deleteGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
+            throw new AccessDeniedException("관리자 권한이 필요합니다.");
+        }
+
+        adminGroupService.deleteGroupByAdmin(groupId);
+
+        return ResponseEntity.ok(
+                new java.util.HashMap<>() {{
+                    put("message", "그룹 삭제 성공");
+                    put("groupId", groupId);
+                }}
+        );
+    }
+
 }

--- a/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
@@ -2,8 +2,10 @@ package com.chingubackend.controller.admin;
 
 import com.chingubackend.dto.admin.response.AdminUserDeleteResponse;
 import com.chingubackend.dto.admin.response.AdminUserResponse;
+import com.chingubackend.dto.response.AdminGroupResponse;
+import com.chingubackend.entity.Group;
 import com.chingubackend.entity.User;
-import com.chingubackend.exception.UserNotFoundException;
+import com.chingubackend.repository.GroupRepository;
 import com.chingubackend.repository.UserRepository;
 import com.chingubackend.service.admin.AdminUserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +30,7 @@ import com.chingubackend.security.CustomUserDetails;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
-public class AdminController {
+public class AdminUserController {
 
     private final UserRepository userRepository;
     private final AdminUserService adminUserService;
@@ -94,6 +96,4 @@ public class AdminController {
 
         return ResponseEntity.ok(new AdminUserDeleteResponse(userId, "회원 삭제 성공"));
     }
-
-
 }

--- a/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
@@ -2,10 +2,7 @@ package com.chingubackend.controller.admin;
 
 import com.chingubackend.dto.admin.response.AdminUserDeleteResponse;
 import com.chingubackend.dto.admin.response.AdminUserResponse;
-import com.chingubackend.dto.response.AdminGroupResponse;
-import com.chingubackend.entity.Group;
 import com.chingubackend.entity.User;
-import com.chingubackend.repository.GroupRepository;
 import com.chingubackend.repository.UserRepository;
 import com.chingubackend.service.admin.AdminUserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,17 +11,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.AccessDeniedException;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.chingubackend.security.CustomUserDetails;
 
 @Tag(name = "Admin", description = "관리자 전용 API")
 @RestController
@@ -35,21 +28,18 @@ public class AdminUserController {
     private final UserRepository userRepository;
     private final AdminUserService adminUserService;
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "관리자 권한 확인", description = "로그인한 사용자가 ROLE_ADMIN 권한을 가졌는지 확인")
     @GetMapping("/check")
-    public ResponseEntity<?> checkAdmin(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
+    public ResponseEntity<?> checkAdmin() {
+
         return ResponseEntity.ok("접근 가능");
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "전체 회원 목록 조회", description = "관리자 권한을 가진 사용자만 전체 회원 정보를 조회할 수 있습니다.")
     @GetMapping("/users")
-    public ResponseEntity<List<AdminUserResponse>> getAllUsers(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
+    public ResponseEntity<List<AdminUserResponse>> getAllUsers() {
 
         List<AdminUserResponse> users = userRepository.findAll().stream()
                 .map(AdminUserResponse::new)
@@ -58,16 +48,12 @@ public class AdminUserController {
         return ResponseEntity.ok(users);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "회원 검색", description = "이름, 닉네임, 사용자 ID를 기준으로 회원을 검색합니다. 관리자 권한 필요.")
     @GetMapping("/users/search")
     public ResponseEntity<List<AdminUserResponse>> searchUsersByAdmin(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "검색 키워드 (이름/닉네임/ID)")
             @RequestParam String keyword) {
-
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
 
         List<User> users = userRepository.searchByKeyword(keyword);
 
@@ -82,15 +68,10 @@ public class AdminUserController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/users/{userId}")
     @Operation(summary = "회원 삭제", description = "관리자가 특정 사용자를 삭제합니다.")
-    public ResponseEntity<AdminUserDeleteResponse> deleteUserByAdmin(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long userId) {
-
-        if (!userDetails.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
-            throw new AccessDeniedException("관리자 권한이 필요합니다.");
-        }
+    public ResponseEntity<AdminUserDeleteResponse> deleteUserByAdmin(@PathVariable Long userId) {
 
         adminUserService.deleteUserByAdmin(userId);
 

--- a/src/main/java/com/chingubackend/dto/admin/response/AdminGroupResponse.java
+++ b/src/main/java/com/chingubackend/dto/admin/response/AdminGroupResponse.java
@@ -1,0 +1,26 @@
+package com.chingubackend.dto.response;
+
+import com.chingubackend.dto.admin.response.GroupMemberSummaryResponse;
+import com.chingubackend.entity.Group;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+@Getter
+public class AdminGroupResponse {
+    private Long groupId;
+    private String groupName;
+    private LocalDateTime createdDate;
+    private List<GroupMemberSummaryResponse> members;
+
+    public AdminGroupResponse(Group group) {
+        this.groupId = group.getId();
+        this.groupName = group.getGroupName();
+        this.createdDate = group.getCreatedAt();
+        this.members = group.getMembers().stream()
+                .filter(member -> member.getUser() != null)
+                .map(member -> GroupMemberSummaryResponse.from(member.getUser()))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/chingubackend/dto/admin/response/GroupMemberSummaryResponse.java
+++ b/src/main/java/com/chingubackend/dto/admin/response/GroupMemberSummaryResponse.java
@@ -1,0 +1,23 @@
+package com.chingubackend.dto.admin.response;
+
+import com.chingubackend.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GroupMemberSummaryResponse {
+    private Long userId;
+    private String name;
+    private String nickname;
+    private String email;
+
+    public static GroupMemberSummaryResponse from(User user) {
+        return new GroupMemberSummaryResponse(
+                user.getId(),
+                user.getName(),
+                user.getNickname(),
+                user.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/chingubackend/entity/Group.java
+++ b/src/main/java/com/chingubackend/entity/Group.java
@@ -1,6 +1,7 @@
 package com.chingubackend.entity;
 
 import jakarta.persistence.*;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,9 @@ public class Group {
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
     }
+
+    @OneToMany(mappedBy = "group", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private List<GroupMember> members;
 
     @Builder
     public Group(String groupName, String description, User creator) {

--- a/src/main/java/com/chingubackend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/chingubackend/exception/GlobalExceptionHandler.java
@@ -2,14 +2,13 @@ package com.chingubackend.exception;
 
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
-import java.util.Optional;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.validation.FieldError;
 
 import java.time.LocalDateTime;
 
@@ -70,6 +69,12 @@ public class GlobalExceptionHandler {
         String errorMessage = String.join("; ", errors);
 
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Validation Failed", errorMessage);
+    }
+
+    @ExceptionHandler(GroupNotFoundException.class)
+    public ResponseEntity<?> handleGroupNotFound(GroupNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("message", ex.getMessage()));
     }
 
     private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus status, String error, String message) {

--- a/src/main/java/com/chingubackend/exception/GroupNotFoundException.java
+++ b/src/main/java/com/chingubackend/exception/GroupNotFoundException.java
@@ -1,0 +1,7 @@
+package com.chingubackend.exception;
+
+public class GroupNotFoundException extends RuntimeException {
+    public GroupNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/chingubackend/repository/GroupInviteRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupInviteRepository.java
@@ -1,5 +1,6 @@
 package com.chingubackend.repository;
 
+import com.chingubackend.entity.Group;
 import com.chingubackend.entity.GroupInvite;
 import com.chingubackend.model.RequestStatus;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -17,4 +18,6 @@ public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> 
     List<GroupInvite> findByReceiverIdWithGroup(@Param("receiverId") Long receiverId);
 
     void deleteBySenderIdOrReceiverId(Long senderId, Long receiverId);
+
+    void deleteByGroup(Group group);
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemberRepository.java
@@ -1,5 +1,6 @@
 package com.chingubackend.repository;
 
+import com.chingubackend.entity.Group;
 import com.chingubackend.entity.GroupMember;
 import com.chingubackend.model.MemberStatus;
 import com.chingubackend.model.RequestStatus;
@@ -16,4 +17,5 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     void deleteByUserId(Long userId);
     boolean existsByGroupIdAndUserId(Long groupId, Long userId);
+    void deleteByGroup(Group group);
 }

--- a/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupMemoryRepository.java
@@ -16,5 +16,6 @@ public interface GroupMemoryRepository extends JpaRepository<GroupMemory, Long> 
 
     List<GroupMemory> findByGroupId(Long groupId);
     List<GroupMemory> findByGroupIdOrderByCreatedDateDesc(Long groupId);
+    void deleteByGroup(Group group);
 
 }

--- a/src/main/java/com/chingubackend/repository/GroupRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupRepository.java
@@ -9,7 +9,11 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     List<Group> findByCreatorId(Long creatorId);
+
     @Modifying
     @Query("UPDATE Group g SET g.creator.id = :newCreatorId WHERE g.creator.id = :originalCreatorId")
     void updateCreatorId(@Param("originalCreatorId") Long originalCreatorId, @Param("newCreatorId") Long newCreatorId);
+
+    @Query("SELECT DISTINCT g FROM Group g " + "LEFT JOIN FETCH g.members gm " + "LEFT JOIN FETCH gm.user")
+    List<Group> findAllWithMembersAndUsers();
 }

--- a/src/main/java/com/chingubackend/repository/GroupScheduleRepository.java
+++ b/src/main/java/com/chingubackend/repository/GroupScheduleRepository.java
@@ -9,4 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GroupScheduleRepository extends JpaRepository<GroupSchedule, Long> {
     List<GroupSchedule> findByGroup(Group group);
     void deleteByUser(User user);
+    void deleteByGroup(Group group);
 }

--- a/src/main/java/com/chingubackend/service/admin/AdminGroupService.java
+++ b/src/main/java/com/chingubackend/service/admin/AdminGroupService.java
@@ -1,0 +1,36 @@
+package com.chingubackend.service.admin;
+
+import com.chingubackend.entity.Group;
+import com.chingubackend.exception.GroupNotFoundException;
+import com.chingubackend.repository.GroupInviteRepository;
+import com.chingubackend.repository.GroupMemberRepository;
+import com.chingubackend.repository.GroupMemoryRepository;
+import com.chingubackend.repository.GroupRepository;
+import com.chingubackend.repository.GroupScheduleRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminGroupService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupInviteRepository groupInviteRepository;
+    private final GroupScheduleRepository groupScheduleRepository;
+    private final GroupMemoryRepository groupMemoryRepository;
+
+    @Transactional
+    public void deleteGroupByAdmin(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new GroupNotFoundException("해당 그룹을 찾을 수 없습니다."));
+
+        groupScheduleRepository.deleteByGroup(group);
+        groupMemberRepository.deleteByGroup(group);
+        groupInviteRepository.deleteByGroup(group);
+        groupMemoryRepository.deleteByGroup(group);
+
+        groupRepository.delete(group);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: #83 

## 📝작업 내용

- 전체 그룹 및 멤버 목록 조회 API 추가
- 그룹 삭제 API 추가
- 중복되던 ROLE_ADMIN 권한 체크를 @PreAuthorize("hasRole('ADMIN')") 방식으로 통합
- if (!userDetails...) 조건문 제거
- SecurityConfig에 @EnableMethodSecurity 적용 여부 확인


## 💬 참고 사항

- 그룹 삭제 시 연관 Repository 메서드 추가됨 (deleteByGroupId 등)
