### PR TITLE
feat: Google OAuth2 소셜 로그인 기능 구현 및 마이페이지 수정 조건 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/chingubackend/security/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/chingubackend/security/oauth/CustomOAuth2User.java
@@ -1,0 +1,50 @@
+package com.chingubackend.security.oauth;
+
+import java.util.Collection;
+import java.util.Map;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final Long userId;
+    private final String email;
+
+    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+                            Map<String, Object> attributes,
+                            String nameAttributeKey,
+                            Long userId,
+                            String email) {
+        this.authorities = authorities;
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.userId = userId;
+        this.email = email;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get(nameAttributeKey);
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/chingubackend/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/chingubackend/security/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,66 @@
+package com.chingubackend.security.oauth;
+
+import com.chingubackend.entity.User;
+import com.chingubackend.model.Role;
+import com.chingubackend.model.SocialType;
+import com.chingubackend.repository.UserRepository;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        System.out.println("✅ CustomOAuth2UserService 호출됨");
+
+        try {
+            OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+            Map<String, Object> attributes = oAuth2User.getAttributes();
+
+            String email = (String) attributes.get("email");
+            String name = (String) attributes.get("name");
+            String picture = (String) attributes.get("picture");
+
+            User user = userRepository.findByEmail(email)
+                    .orElseGet(() -> {
+                        User newUser = User.builder()
+                                .userId(UUID.randomUUID().toString())
+                                .name(name)
+                                .nickname("user_" + UUID.randomUUID().toString().substring(0, 8))
+                                .email(email)
+                                .password("NO_PASSWORD")
+                                .profilePictureUrl(picture)
+                                .socialType(SocialType.GOOGLE)
+                                .role(Role.ROLE_USER)
+                                .build();
+                        return userRepository.save(newUser);
+                    });
+
+            return new CustomOAuth2User(
+                    Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                    attributes,
+                    "email",
+                    user.getId(),
+                    user.getEmail()
+            );
+
+        } catch (Exception e) {
+            System.out.println("❌ CustomOAuth2UserService 예외 발생: " + e.getMessage());
+            e.printStackTrace();  // 콘솔에 전체 스택 출력
+            throw new OAuth2AuthenticationException(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/chingubackend/security/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/chingubackend/security/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,38 @@
+package com.chingubackend.security.oauth;
+
+import com.chingubackend.jwt.JwtUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtil jwtUtil; // ✅ JwtUtil 주입
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        System.out.println("✅ OAuth2SuccessHandler 진입, JWT 발급 중...");
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+
+        Long userId = oAuth2User.getUserId();
+        String email = oAuth2User.getEmail();
+        String nickname = oAuth2User.getAttributes().get("name").toString(); // 또는 DB에서 가져온 nickname
+
+        String token = jwtUtil.generateToken(userId, email, nickname); // ✅ JWT 발급
+
+        // 프론트로 리디렉션 + JWT 전달
+        String redirectUrl = "https://chinguchingu.vercel.app/oauth2/success?token=" + token;
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,8 +20,8 @@ spring.jpa.show-sql=true
 jwt.secret=${JWT_SECRET_KEY}
 
 # Log
-logging.level.org.springframework.security=DEBUG
-logging.level.com.chingubackend=DEBUG
+logging.level.org.springframework.security=TRACE
+logging.level.com.chingubackend=TRACE
 
 # Redis
 spring.data.redis.host=${REDIS_HOST}
@@ -48,3 +48,15 @@ cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket=chingu-album
 cloud.aws.stack.auto=false
+
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.google.scope=profile,email
+spring.security.oauth2.client.registration.google.client-name=Google
+
+spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/v2/auth
+spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
+spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v3/userinfo
+spring.security.oauth2.client.provider.google.user-name-attribute=sub


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: #93 

## 📝작업 내용

- Google OAuth2 로그인 구현
- 사용자 정보(email, name 등)로 신규 회원 자동 등록
- JWT 발급 후 프론트로 리디렉션 (`/oauth2/success`)
- `User` 엔티티에 `socialType` 필드 적용
- 마이페이지 수정 시 `socialType != NONE`이면 비밀번호 수정 불가하도록 예외 처리
- 소셜 로그인 회원 탈퇴 시 비밀번호 확인 과정 X
- JWT 발급 로직 연동


## 💬 참고 사항

- application.properties에 OAuth2 관련 환경 변수 추가 (환경 변수 문서에 추가 완료)
