### PR TITLE
Fix/friend search

### DIFF
--- a/src/main/java/com/chingubackend/config/SecurityConfig.java
+++ b/src/main/java/com/chingubackend/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions().disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용 X
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(
                                 "/auth/login",
                                 "/auth/signup",
@@ -81,6 +81,7 @@ public class SecurityConfig {
                                 "/api/users/check-userId",
                                 "/api/users/check-nickname",
                                 "/api/users/find-userId",
+                                "/api/users/search",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/h2-console/**",
@@ -120,7 +121,7 @@ public class SecurityConfig {
                 "http://localhost:3000",
                 "https://chinguchingu.kro.kr",
                 "https://chingu-frontend.vercel.app",
-                "https://chinguchingu.vercel.app/"
+                "https://chinguchingu.vercel.app"
         ));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));

--- a/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
+++ b/src/main/java/com/chingubackend/controller/admin/AdminUserController.java
@@ -8,7 +8,9 @@ import com.chingubackend.service.admin.AdminUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -49,23 +51,21 @@ public class AdminUserController {
     }
 
     @PreAuthorize("hasRole('ADMIN')")
-    @Operation(summary = "회원 검색", description = "이름, 닉네임, 사용자 ID를 기준으로 회원을 검색합니다. 관리자 권한 필요.")
+    @Operation(summary = "회원 검색", description = "이름, 닉네임, 사용자 ID를 기준으로 회원을 검색합니다.")
     @GetMapping("/users/search")
     public ResponseEntity<List<AdminUserResponse>> searchUsersByAdmin(
             @Parameter(description = "검색 키워드 (이름/닉네임/ID)")
             @RequestParam String keyword) {
+        List<AdminUserResponse> users = adminUserService.searchUsers(keyword);
 
-        List<User> users = userRepository.searchByKeyword(keyword);
+        Map<String, Object> response = new HashMap<>();
+        response.put("users", users);
 
         if (users.isEmpty()) {
-            return ResponseEntity.status(404).build();
+            response.put("message", "일치하는 회원이 없습니다.");
         }
 
-        List<AdminUserResponse> response = users.stream()
-                .map(AdminUserResponse::new)
-                .toList();
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(users);
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/chingubackend/repository/UserRepository.java
+++ b/src/main/java/com/chingubackend/repository/UserRepository.java
@@ -1,7 +1,7 @@
 package com.chingubackend.repository;
 
 import com.chingubackend.entity.User;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,9 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByNameAndEmail(String name, String email);
     Optional<User> findByUniqueKey(String uniqueKey);
     boolean existsByNickname(String nickname);
-    List<User> findByNameOrNicknameOrUserId(String name, String nickname, String userId);
-
-    // 관리자 회원 검색 시
-    @Query("SELECT u FROM User u WHERE u.name LIKE %:keyword% OR u.nickname LIKE %:keyword% OR u.userId LIKE %:keyword%")
-    List<User> searchByKeyword(@Param("keyword") String keyword);
+    List<User> findByNameContainingIgnoreCaseOrNicknameContainingIgnoreCase(
+            String name, String nickname);
 }

--- a/src/main/java/com/chingubackend/service/UserService.java
+++ b/src/main/java/com/chingubackend/service/UserService.java
@@ -146,8 +146,17 @@ public class UserService {
     }
 
     public List<UserResponse> searchUsers(String keyword) {
-        List<User> users = userRepository.findByNameOrNicknameOrUserId(keyword, keyword, keyword);
-        return users.stream().map(UserResponse::fromEntity).collect(Collectors.toList());
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return List.of(); // 공백 검색 시 전체 조회 방지
+        }
+
+        List<User> users = userRepository
+                .findByNameContainingIgnoreCaseOrNicknameContainingIgnoreCase(
+                        keyword, keyword);
+
+        return users.stream()
+                .map(UserResponse::fromEntity)
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/chingubackend/service/admin/AdminUserService.java
+++ b/src/main/java/com/chingubackend/service/admin/AdminUserService.java
@@ -1,9 +1,11 @@
 package com.chingubackend.service.admin;
 
+import com.chingubackend.dto.admin.response.AdminUserResponse;
 import com.chingubackend.entity.User;
 import com.chingubackend.exception.UserNotFoundException;
 import com.chingubackend.repository.*;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,19 @@ public class AdminUserService {
     private final ScheduleRepository scheduleRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupScheduleRepository groupScheduleRepository;
+
+    public List<AdminUserResponse> searchUsers(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return List.of(); // 공백 검색 시 전체 조회 방지
+        }
+
+        List<User> users = userRepository
+                .findByNameContainingIgnoreCaseOrNicknameContainingIgnoreCase(keyword, keyword);
+
+        return users.stream()
+                .map(AdminUserResponse::new)
+                .toList();
+    }
 
     @Transactional
     public void deleteUserByAdmin(Long targetUserId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,14 @@ jwt.secret=${JWT_SECRET_KEY}
 logging.level.org.springframework.security=TRACE
 logging.level.com.chingubackend=TRACE
 
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.use_sql_comments=true
+
+
 # Redis
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: #126 

## 📝작업 내용

- 친구 검색 시 헤더 인증 없이 가능하게 수정
- 일부 키워드로도 검색 가능하게 수정
- 이름/닉네임 기준으로만 검색되게 수정
- 관리자 회원 검색 시 서비스 계층 거쳐서 컨트롤러로 갈 수 있게 로직 분리 (리팩토링)


## 💬 참고 사항

- 참고 사항 및 스크린샷이 있다면 작성해주세요. (없다면 빈칸)
